### PR TITLE
support pythons that lacks datetime.fromisoformat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyotp==2.3.0
 Pillow==7.1.0
 pyscreenshot==1.0
 zbar-py==1.0.4
+python-dateutil==2.8.1


### PR DESCRIPTION
Python 3.7 got the `datetime.fromisoformat` method, but earlier
versions don't have it. Use `dateutil.parser.isoparse` instead.